### PR TITLE
Support configurable ticket match regex

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tempoit"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Samuel Walladge <samuel@swalladge.net>"]
 description = "Simple timewarrior to tempo/jira worklog uploader."
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ username = 'my_username'
 password = 'my_password'
 # base url of the jira instance
 base_url = 'https://tasks.opencraft.com'
+# be careful with backslashes; use single quoted string to avoid needing double backslashes in reex
+ticket_regex = '^(?i:SE|BB|OC|MNG|BIZ|ADMIN)-\d+$'
 ```
 
 ## Usage


### PR DESCRIPTION
This may be helpful for other use cases,
and I needed to update for the new Falcon cell anyway (FAL currently).

Bumped the major version number, because this is a breaking change (config file requires the `ticket_regex` key now).