### PR TITLE
feat: adds path to tempoit config for mac users

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,12 @@ uploads them, and marks them as uploaded in timewarrior by modifying the tags.
 Install from crates: `cargo install tempoit`, or clone this repository and `cargo run` or `cargo build`.
 You should have a recent stable rust toolchain installed.
 
-On first run, `~/.config/tempoit/tempoit.toml` (or equivalent default path for your system) will be created.
+On first run, a default `tempoit/tempoit.toml` configuration file will be created in your [`config_dir`](https://crates.io/crates/directories-next#user-content-basedirs).
+
+You can find the configuration file using the following paths, based on which system you're using.
+* Linux: `$HOME/.config/tempoit/tempoit.toml`
+* Windows: `{FOLDERID_RoamingAppData}/tempoit/tempoit.toml`
+* macOS: `$HOME/Library/Application Support/rs.tempoit/tempoit.toml`
 
 Configure to suit - example below:
 
@@ -28,7 +33,7 @@ password = 'my_password'
 # base url of the jira instance
 base_url = 'https://tasks.opencraft.com'
 # be careful with backslashes; use single quoted string to avoid needing double backslashes in reex
-ticket_regex = '^(?i:SE|BB|OC|MNG|BIZ|ADMIN)-\d+$'
+ticket_regex = '^(?i:FAL|SE|BB|OC|MNG|BIZ|ADMIN)-\d+$'
 ```
 
 ## Usage


### PR DESCRIPTION
I recently had to install this script on a Mac. Unfortunately, I kept running into issues with the login. 

After some investigation, it turns out that `confy`, which is the package used to serialize and deserialize the `tempoit.toml` config, uses `directories` to locate the configuration file path.

According to the [`directories` docs](https://crates.io/crates/directories), the `preference_dir`, which is `$HOME/.config` on Linux, is `$HOME/Library/Preferences` on Mac and `{FOLDERID_RoamingAppData}` on Windows.

However, it's important to note that this will not remain the case with `confy = 0.5.0' due to a [breaking change](https://github.com/rust-cli/confy/blob/664992aecd97b4af0eda8d9d2825885662e1c6b4/README.md#version-050). The breaking change is that `confy` switched from `directories` to `directories-next` because the former is no longer maintained.

Accordingly, in the future, once `confy = 0.5.0` is available on cargo, the README should be updated again to the `config_dir` mentioned on the [`directories-next` docs](https://crates.io/crates/directories-next). Although the config location on windows will remain the same, on Mac it will become `$HOME/Library/Application Support`. 

---

If you don't like to mention the path of the config for Mac, I can make a change to link to the docs mentioned earlier. It would immensely help anyone who hasn't touched rust, ever, like myself 😛 

---

Reviewers:

- [ ] @swalladge 